### PR TITLE
fix: add missing opencv dependencies

### DIFF
--- a/DockerFile
+++ b/DockerFile
@@ -1,5 +1,8 @@
 FROM python:3.8-slim
 
+# Install dependencies for OpenCV
+RUN apt-get update && apt-get -y install libgl1 libglib2.0-0
+
 RUN mkdir /app
 
 RUN pip install pipenv


### PR DESCRIPTION
This PR adds missing `opencv` dependencies to the `Dockerfile`.

Closes #68 