### PR TITLE
fix: verify that period is a valid unit in convert_time

### DIFF
--- a/bot/cogs/utilities.py
+++ b/bot/cogs/utilities.py
@@ -5,22 +5,30 @@ from discord.ext import tasks
 from discord.ext.commands import Bot, Cog, command
 from bot import settings
 
+# Define the time period units user can pass
+VALID_PERIODS = (
+    "s sec secs second seconds m min mins minute minutes h hour hours".split()
+)
+
 
 def convert_time(time, period) -> int:
     """Converts the given time and period (i.e 10 minutes) to seconds"""
 
-    result = None
     try:
+        # Strip at most one trailing s (if the string is not just "s")
+        # Using rstrip() would let people enter "sss" which would return ""
+        if len(period) > 1 and period[-1] == "s":
+            period = period[:-1]
         time = int(time)
-        if "sec" in period:
-            result = time
-        elif "min" in period:
-            result = time * 60
-        elif "hour" in period:
-            result = time * (60 ** 2)
+        if period in ("s", "sec", "second"):
+            return time
+        if period in ("m", "min", "minute"):
+            return time * 60
+        if period in ("h", "hour"):
+            return time * (60 ** 2)
     except ValueError:
         pass
-    return result
+    return None
 
 
 class Utilities(Cog):
@@ -105,7 +113,7 @@ class Utilities(Cog):
                 ctx=ctx, time=time, period=period, task_type="reminder", reason=reason
             )
 
-            if period in ["second", "seconds", "minute", "minutes", "hour", "hours"]:
+            if period in VALID_PERIODS:
                 if self.reminder_tasks[ctx.author.id] > 0:
                     await ctx.send(
                         f"{ctx.author.mention} I will remind you about {reason} in {time} {period}"


### PR DESCRIPTION
This PR fixes the bug in the `convert_time` function. It also allows more flexibility in adding a reminder by accepting 13 different unit (with plural and singular forms where reasonable) keywords, so you can do `.reminder 10 s wow it's been 10 seconds!`

Closes #86 