### PR TITLE
Added dynamic help command

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -10,15 +10,44 @@ if __name__ == "__main__":
     bot = Bot(command_prefix=settings.COMMAND_PREFIX)
     bot.remove_command("help")
     @bot.command(name="help",help="This will be shown")
-    async def help(ctx):
+    async def help(ctx, *, name=None):
         embed=discord.Embed(title="Friendo_Bot", url="https://github.com/Aravindha1234u/Friendo_Bot",color=0x1c1c1c)
         embed.set_thumbnail(url="https://images.discordapp.net/avatars/723555941118771262/8f586ecb1f89cec031d00b3a616573ea.png?size=512")
-        embed.add_field(name="Events", value="events   Usage: `.events show \"[*args]\"`", inline=False)
-        embed.add_field(name="Fun", value="- 8ball     Ask any question to the 8ball \n- blackjack Play blackjack with the Friendo Bot\n- flip      simulates a coin toss\n- tosponge  Alternate case of inputted text\n- uwu       uwuify any text you like", inline=False)
-        embed.add_field(name="Greeting", value="hello Say hello", inline=True)
-        embed.add_field(name="Memes", value="meme generator commands. Usage: `.meme [command] [*args]`", inline=False)
-        embed.add_field(name="Segmentation", value="segment Send an image and get a segmented one back", inline=False)
-        embed.add_field(name="Utilities", value="- drink     Starts a 10 minute drink session to stay hydrated\n- ping      Shows the latency between Friendo and the Discord API\n- reminder  [number] [unit (seconds/minutes/hours)] [reason for reminder]\n- version   Returns Friendo's Version", inline=False)
+
+        if name is None:
+            cogs = list(bot.cogs.keys())
+            field_body = "\n".join(cogs)
+            field_body = field_body.strip()
+
+            field_body += "\n\nUsage: `%shelp [Cog | Command]`. Example: `%shelp greetings`" % (bot.command_prefix, bot.command_prefix)
+
+            embed.add_field(name="Cogs", value=field_body, inline=False)
+        else:
+            cog = bot.cogs.get(name.title(), None)
+
+            if cog is None:
+                # Check if this is not a command
+                command = bot.get_command(name.lower())
+
+                if command is not None:
+                    embed.title += " - " + command.name
+
+                    field_body = (command.description if command.description != "" else (command.brief if command.brief != "" else"This command has no description."))
+                    field_body += '\n' + ("Usage: `" + command.usage + "`" if command.usage is not None else "")
+
+                    embed.add_field(name=command.name, value=field_body.strip(), inline=False)
+                else:
+                    field_body = "Error: Cog or command `%s` not found! Use `%shelp` to see a list of cogs" % (name, bot.command_prefix)
+                    embed.add_field(name="Cogs", value=field_body, inline=False)
+            else:
+                embed.title += " - " + name.title()
+
+                for command in cog.get_commands():
+                    field_body = (command.brief if command.brief is not None else "") + "\n" +  ("Usage: `" + command.usage + "`" if command.usage is not None else "")
+                    field_body = field_body.strip()
+
+                    embed.add_field(name=command.name, value=(field_body + "\n" if field_body != "" else "This command has no help message"), inline=False)
+
         await ctx.send(embed=embed)
 
     # load in basic commands
@@ -34,11 +63,11 @@ if __name__ == "__main__":
 
     # load in Admin commands
     bot.load_extension("bot.cogs.admin")
-    
-    #load in Trivia commands
+
+    # load in Trivia commands
     bot.load_extension("bot.cogs.trivia")
-    
-    #load in weather command
+
+    # load in weather command
     bot.load_extension("bot.cogs.weather")
 
     # load in Fun commands
@@ -48,6 +77,3 @@ if __name__ == "__main__":
     bot.load_extension("bot.cogs.events")
 
     bot.run(settings.TOKEN)
-    
- 
-    


### PR DESCRIPTION
## Behavior of this implementation:
This will print the cogs on `.help`
![image](https://user-images.githubusercontent.com/57736901/94993138-e14d4600-055c-11eb-9327-56d11dbb827f.png)

You can then run it with a parameter that is either a Cog name or a command name. The Cog name will be checked first. If a Cog is asked it'll show all commands of that Cog with their `.brief` description each and `.usage` too if possible. If a command is asked it'll show their `.description` defaulting to `.brief` if not present and their `.usage` if possible.

This is attached to issue #95 