### PR TITLE
bug fixed: source help command links to original repo now

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
         char_repeat = 20
         embed = discord.Embed(
             title=f"{'-' * (char_repeat//2)}Friendo_Bot{'-' * (char_repeat//2)}",
-            url="https://github.com/Aravindha1234u/Friendo_Bot",
+            url=settings.BASE_GITHUB_REPO,
             color=0x1C1C1C,
         )
         embed.set_thumbnail(


### PR DESCRIPTION
Fixed the bug which links you to the author repo in the help command, now links to the base repo in settings.py