### PR TITLE
fix: properly await response to fix coroutine error

### DIFF
--- a/bot/cogs/covid_stats.py
+++ b/bot/cogs/covid_stats.py
@@ -63,7 +63,7 @@ class CovidStats(Cog):
         """Acquires Covid statistics about a specific country."""
         async with self.bot.session.get(COVID_URL) as resp:
             assert resp.status == 200, resp.raise_for_status()
-            read = await resp.json()["Countries"]
+            read = (await resp.json())["Countries"]
 
             data = []
             for _ in read:


### PR DESCRIPTION
There was a bug from the refactor that caused us to attempt to use __get__ on a coroutine. I added parenthesis so we are getting the key from the response, rather than the coroutine.