### PR TITLE
AoC 2020 commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ To get a bot token go to [Discord Developer Portal](https://discord.com/develope
 
 5. Create a [Open Weather](https://openweathermap.org/price) api account (a free account works for this)
 
-6. Create a file `bot.env` in the root project directory and fill it out using the example below
+6. Get your AoC session cookie, see how - https://github.com/wimglenn/advent-of-code-wim/issues/1
 
-7. `docker-compose up --build -d`
+7. Create a file `bot.env` in the root project directory and fill it out using the example below
+
+8. `docker-compose up --build -d`
 
 ```text
 # bot.env
@@ -29,7 +31,8 @@ MEME_USERNAME = <your imgflip api username>
 MEME_PASSWORD = <your imgflip api password>
 EVENT_API_KEY = <your ticketmaster api key>
 MUSIC_TOKEN = <your Last.fm api key>
-WEATHER_TOKEN = <you open weather token>
+WEATHER_TOKEN = <your open weather token>
+AOC_SESSION_COOKIE = <your advent of code session cookie>
 ```
 
 ## Dev Installation

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -51,4 +51,7 @@ if __name__ == "__main__":
     # loads the pixelate cog
     bot.load_extension("bot.cogs.pixelate")
 
+    # loads the advent of code cog
+    bot.load_extension("bot.cogs.advent_of_code")
+
     bot.run(settings.TOKEN)

--- a/bot/cogs/advent_of_code.py
+++ b/bot/cogs/advent_of_code.py
@@ -1,0 +1,78 @@
+from bot.bot import Friendo
+from discord import errors
+from discord.ext.commands import Cog, Context, group
+from bot.settings import AOC_LEADERBOARD_LINK, AOC_SESSION_COOKIE
+
+cookie = {'session': AOC_SESSION_COOKIE}
+join_code = '442826-ab5b0efd'
+
+
+class AdventOfCode(Cog):
+    """Cog for AOC 2020 for small features."""
+
+    def __init__(self, bot: Friendo):
+        self.bot = bot
+
+    @staticmethod
+    def sort_stats(stat_d: dict) -> dict:
+        """Staticmethod for making a sorted dictionary of the leaderboard."""
+        stats = dict()
+        for ms in stat_d['members']:
+            if stat_d['members'][ms]['name'] is None:
+                stat_d['members'][ms]['name'] = 'Anonymous'
+            stats.update({(stat_d['members'][ms]['name'],
+                         stat_d['members'][ms]['stars']): stat_d['members'][ms]['local_score']})
+
+        stats = {k: stats[k] for k in sorted(stats, key=lambda y: stats[y])[::-1]}
+        return stats
+
+    @group(name="adventofcode", aliases=('aoc', 'aoc2020'))
+    async def aoc_group(self, ctx: Context) -> None:
+        """Group for advent of code commands."""
+        if not ctx.invoked_subcommand:
+            await ctx.send("Please enter a valid command")
+
+    @aoc_group.command(brief="Get the leaderboard join code in your DM's",
+                       usage=".join",
+                       aliases=("join", "join_lb", "j"))
+    async def join_leaderboard(self, ctx: Context) -> None:
+        """Dms the author the join code and link for the leaderboard."""
+        info = [
+            "To join our leaderboard, follow these steps:",
+            "• Log in on https://adventofcode.com",
+            "• Head over to https://adventofcode.com/leaderboard/private",
+            f"• Use this code `{join_code}` to join the Code Collective leaderboard!"]
+        error_msg = f":x: {ctx.author.mention}, please (temporarily) enable DMs to receive the join code"
+
+        await ctx.message.add_reaction("📨")
+        try:
+            await ctx.author.send('\n'.join(info))
+        except errors.Forbidden:
+            await ctx.send(error_msg)
+
+    @aoc_group.command(brief="Get the leaderboard of AoC 2020 for this server",
+                       usage=".leaderboard",
+                       aliases=('lb', 'board'))
+    async def leaderboard(self, ctx: Context) -> None:
+        """Shows the leaderboard of code collective server for AoC 2020."""
+        async with ctx.channel.typing():
+            async with self.bot.session.get(AOC_LEADERBOARD_LINK, cookies=cookie) as stats:
+                stats = await stats.json()
+                sorted_stats = self.sort_stats(stats)
+                msg = []
+                count = 1
+
+                for name_star, score in sorted_stats.items():
+                    msg.append(
+                        f"{count} | {name_star[0] + ' '*(16-len(name_star[0]))} "
+                        f"|  {name_star[1]} ★  |   {score}")
+                    count += 1
+
+                msg = '\n'.join(msg)
+                await ctx.send("🎄 Advent of Code 2020 leaderboard for Code Collective 🎄")
+                await ctx.send(f"```  | Name {' '*(16-4)}| Stars | Score\n{msg}```")
+
+
+def setup(bot: Friendo) -> None:
+    """Sets up the AdventOfCode cog."""
+    bot.add_cog(AdventOfCode(bot))

--- a/bot/cogs/advent_of_code.py
+++ b/bot/cogs/advent_of_code.py
@@ -26,14 +26,17 @@ class AdventOfCode(Cog):
         stats = {k: stats[k] for k in sorted(stats, key=lambda y: stats[y])[::-1]}
         return stats
 
-    @group(name="adventofcode", aliases=('aoc', 'aoc2020'))
+    @group(name="AdventofCode",
+           aliases=('aoc', 'aoc2020'),
+           brief="Small commands for AoC 2020",
+           usage=".aoc [command]")
     async def aoc_group(self, ctx: Context) -> None:
         """Group for advent of code commands."""
         if not ctx.invoked_subcommand:
             await ctx.send("Please enter a valid command")
 
     @aoc_group.command(brief="Get the leaderboard join code in your DM's",
-                       usage=".join",
+                       usage=".aoc join",
                        aliases=("join", "join_lb", "j"))
     async def join_leaderboard(self, ctx: Context) -> None:
         """Dms the author the join code and link for the leaderboard."""
@@ -50,8 +53,8 @@ class AdventOfCode(Cog):
         except errors.Forbidden:
             await ctx.send(error_msg)
 
-    @aoc_group.command(brief="Get the leaderboard of AoC 2020 for this server",
-                       usage=".leaderboard",
+    @aoc_group.command(brief="Get the leaderboard of AoC 2020 for the Code Collective server",
+                       usage=".aoc leaderboard",
                        aliases=('lb', 'board'))
     async def leaderboard(self, ctx: Context) -> None:
         """Shows the leaderboard of code collective server for AoC 2020."""

--- a/bot/settings.py
+++ b/bot/settings.py
@@ -16,8 +16,12 @@ WOLFRAM_APPID = environ.get("WOLFRAM_APPID")
 
 WEATHER_TOKEN = environ.get("WEATHER_TOKEN")
 
+AOC_SESSION_COOKIE = environ.get("AOC_SESSION_COOKIE")
+
 VERSION = "1.2"
 
 GITHUB_REPO = "https://github.com/fisher60/Friendo_Bot"
+
+AOC_LEADERBOARD_LINK = "https://adventofcode.com/2020/leaderboard/private/view/442826.json"
 
 API_COGS = ["events", "memes"]


### PR DESCRIPTION
Added  2 commands for Code Collective server for AoC 2020, join (to join the Code Collective leaderboard) and leaderboard (to view the leaderboard)
closes #162 