### PR TITLE
Added `allowed_mentions` to the Bot Instantiation

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -1,9 +1,12 @@
-from discord import Intents
+from discord import Intents, AllowedMentions
 from . import settings
 from bot.bot import Friendo
 
 if __name__ == "__main__":
-    bot = Friendo(command_prefix=settings.COMMAND_PREFIX, help_command=None, intents=Intents.all())
+    bot = Friendo(
+        command_prefix=settings.COMMAND_PREFIX, help_command=None, intents=Intents.all(),
+        allowed_mentions=AllowedMentions(everyone=False),
+    )
 
     # load help command
     bot.load_extension("bot.cogs.help")

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -1,4 +1,4 @@
-from discord import Intents, AllowedMentions
+from discord import AllowedMentions, Intents
 from . import settings
 from bot.bot import Friendo
 


### PR DESCRIPTION
Added `allowed_mentions` to the Bot Instantiation so that it cannot mention @everyone. This is a Discord.py feature.