### PR TITLE
Improve output of timezone command

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -48,7 +48,7 @@ class Friendo(Bot):
 
     async def close(self) -> None:
         """Make sure connections are closed properly."""
-        await super().logout()
+        await super().close()
 
         if self.graphql:
             await self.graphql.close()

--- a/bot/cogs/timezone_tracker.py
+++ b/bot/cogs/timezone_tracker.py
@@ -156,6 +156,9 @@ class TimeZoneTracker(Cog):
             if not user["discord_id"]:
                 log.error(f"User found without a discord_id!\n{user}")
                 continue
+            if not user["timezone_name"]:
+                log.info(f"User doesn't have tz listed, skipping\n{user}")
+                continue
             if int(user["discord_id"]) in guild_member_ids:
                 members_with_tz[int(user["discord_id"])] = user["timezone_name"]
         return members_with_tz

--- a/bot/cogs/timezone_tracker.py
+++ b/bot/cogs/timezone_tracker.py
@@ -148,6 +148,8 @@ class TimeZoneTracker(Cog):
         guild_member_ids = {member.id for member in guild.members}
         members_with_tz = {}
         for user in resp["data"]["allUsers"]:
+            if not user["discord_id"]:
+                continue
             if int(user["discord_id"]) in guild_member_ids:
                 members_with_tz[int(user["discord_id"])] = user["timezone_name"]
         return members_with_tz

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,5 @@ services:
     env_file: bot.env
 
     volumes:
-      - ./logs:/app/bot/logs
+      - ./logs:/app/logs
       - ./bot:/app/bot


### PR DESCRIPTION
Make the time appear first, without the seconds displayed, for ease of scanning.
Also sort the output by timestamp.