### PR TITLE
Update CI and add CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,56 @@
-name: Build Checks
+name: Build and deploy a Docker image
 
-on: [pull_request]
+on:
+  workflow_run:
+    workflows: ["Linting"]
+    push:
+    branches:
+      - master
+    types:
+      - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   build:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push'
+    name: Build & Push to GHCR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - name: Create a short SHA tag
+        id: sha_tag
+        run: |
+          tag=$(cut -c 1-7 <<< $GITHUB_SHA)
+          echo "::set-output name=tag::$tag"
 
-      - name: Docker Build
-        run: docker build --tag bot:dry-run .
-        env:
-          FRIENDO_TOKEN: ${{ secrets.DEV_TOKEN }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: Friendo_Bot
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to ghcr
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN  }}
+
+      - name: Build and Push to ghcr
+        uses: docker/build-push-action@v2
+        with:
+          context: Friendo_Bot/
+          file: Friendo_Bot/Dockerfile
+          push: true
+          cache-from: type=registry,ref=ghcr.io/fisher60/Friendo_Bot:latest
+          cache-to: type=inline
+          tags: |
+            ghcr.io/fisher60/Friendo_Bot:latest
+            ghcr.io/fisher60/Friendo_Bot:${{ steps.sha_tag.outputs.tag }}
+          build-args: |
+            git_sha=${{ github.sha }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,24 +1,74 @@
 name: Linting
 
-on: pull_request
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
-
+    name: Linting
     runs-on: ubuntu-latest
+    env:
+      # Configure pip to cache dependencies and do a user install
+      PIP_NO_CACHE_DIR: false
+      PIP_USER: 1
 
+      # Hide the graphical elements from pipenv's output
+      PIPENV_HIDE_EMOJIS: 1
+      PIPENV_NOSPIN: 1
+
+      # Make sure pipenv does not try reuse an environment it's running in
+      PIPENV_IGNORE_VIRTUALENVS: 1
+
+      # Specify explicit paths for python dependencies and the pre-commit
+      # environment so we know which directories to cache
+      PYTHONUSERBASE: ${{ github.workspace }}/.cache/py-user-base
+      PRE_COMMIT_HOME: ${{ github.workspace }}/.cache/pre-commit-cache
     steps:
-      - uses: actions/checkout@v2
+      - name: Add custom PYTHONUSERBASE to PATH
+        run: echo '${{ env.PYTHONUSERBASE }}/bin/' >> $GITHUB_PATH
+      - name: Checkout repo
+        uses: actions/checkout@v2
 
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: '3.9'
 
+      - name: Python Dependency Caching
+        uses: actions/cache@v2
+        id: python_cache
+        with:
+          path: ${{ env.PYTHONUSERBASE }}
+          key: "python-0-${{ runner.os }}-${{ env.PYTHONUSERBASE }}-\
+          ${{ steps.python.outputs.python-version }}-\
+          ${{ hashFiles('./Pipfile', './Pipfile.lock') }}"
+
+      # Install deps, skipping if we hit a cache
       - name: Install dependencies
+        if: steps.python_cache.outputs.cache-hit != 'true'
         run: |
           pip install pipenv
           pipenv install --dev --deploy --system
-      - name: Lint with flake8
+
+      - name: Pre-commit Environment Caching
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.PRE_COMMIT_HOME }}
+          key: "precommit-0-${{ runner.os }}-${{ env.PRE_COMMIT_HOME }}-\
+          ${{ steps.python.outputs.python-version }}-\
+          ${{ hashFiles('./.pre-commit-config.yaml') }}"
+
+      - name: Run pre-commit hooks
+        run: export PIP_USER=0; SKIP=flake8 pre-commit run --all-files
+
+      - name: Lint Flake8
         run: |
           flake8 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,27 @@ FROM python:3.9-slim
 
 RUN apt-get update && apt-get -y install git
 
-RUN mkdir /app
+# Set pip to have cleaner logs and no saved cache
+ENV PIP_NO_CACHE_DIR=false \
+    PIPENV_IGNORE_VIRTUALENVS=1 \
+    PIPENV_NOSPIN=1
 
+WORKDIR /app
+
+# Install pipenv
 RUN pip install pipenv
 
-COPY . /app/
+# Copy deps and lockfile
+COPY Pipfile Pipfile.lock /app/
 
-WORKDIR /app/
-
+# Install project deps
 RUN pipenv install --system --deploy
 
-ENTRYPOINT ["python3"]
-CMD ["-m", "bot"]
+# Set SHA build argument
+ARG git_sha="development"
+ENV GIT_SHA=$git_sha
+
+# Copy in rest of code last, for caching
+COPY . /app/
+
+CMD ["python3", "-m", "bot"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,11 @@
+version: "3.7"
+
+services:
+
+  bot:
+    image: ghcr.io/Fisher60/Friendo_Bot:latest
+    tty: true
+    env_file: bot.env
+    volumes:
+      - ./logs:/app/logs
+      - ./bot:/app/bot


### PR DESCRIPTION
This updates the CI to add pre-commit and caching, along with adding a deploy workflow.

The deploy workflow currently only pushed to GHCR, but can be expanded in future to also deploy to the server running Friendo.

As part of this, I have also added a github sha tag to the build processs o we can remove the git apt dep once we have setup CD and use this in the version cog. 